### PR TITLE
Update get_entities.sh to correctly link entities containing dashes

### DIFF
--- a/merpy/MER/get_entities.sh
+++ b/merpy/MER/get_entities.sh
@@ -191,7 +191,7 @@ get_entities_source () {
     if [ -e "$source"_links.tsv ]; then
         while read -r line; do
             local label=$(cut -d$'\t' -f3- <<< "$line")
-            local text=$(sed "s/[^[:alnum:][:space:]()]/./g" <<< "$label") # Replace special characters
+            local text=$(sed "s/[^[:alnum:][:space:]()-]/./g" <<< "$label") # Replace special characters
             text=$(sed -e 's/[[:space:]()@]\+/ /g' <<< "$text") # Remove multiple whitespace
             text=$(sed -e 's/\.$//' -e 's/\. / /g' <<< "$text") # Remove full stops
             text=$(tr '[:upper:]' '[:lower:]' <<< "$text") # Make text lowercase


### PR DESCRIPTION
Normally, merpy doesn't consider the dash "-" a special character in entity names, resulting in entities containing dashes ending up linking with the wrong IDs, as is shown below:

![image](https://github.com/user-attachments/assets/88cda138-2ffb-4444-96b6-478c0e1efbce)

The change made results in the expected result:

![image](https://github.com/user-attachments/assets/7748227a-3e59-41ba-b995-782d9a0ce36c)